### PR TITLE
Fix passing secrets into reusable deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,10 @@ jobs:
     with:
       environment: Staging
       environment_url: https://stg.remembit.app
+    secrets:
+      FIREBASE_CONFIG: ${{ secrets.FIREBASE_CONFIG }}
+      FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+      FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 
   production:
     name: Production

--- a/.github/workflows/reusable_deploy.yml
+++ b/.github/workflows/reusable_deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: reusable_deploy
 
 on:
   workflow_call:

--- a/.github/workflows/reusable_deploy.yml
+++ b/.github/workflows/reusable_deploy.yml
@@ -9,6 +9,13 @@ on:
       environment_url:
         type: string
         required: true
+    secrets:
+      FIREBASE_CONFIG:
+        required: true
+      FIREBASE_PROJECT_ID:
+        required: true
+      FIREBASE_TOKEN:
+        required: true
 
 jobs:
   deploy:


### PR DESCRIPTION
### Added
- Inputs for secrets on reusable workflow

### Changed
- Renamed reusable deploy workflow for easier readability in GitHub Actions